### PR TITLE
Bomb print error - 1.1.5-hotfix

### DIFF
--- a/cogs/crime.py
+++ b/cogs/crime.py
@@ -426,7 +426,7 @@ class Crime(commands.Cog):
         await self.bot.inventories.upsert({"_id": ctx.author.id, "inventory": inventory})
         await self.bot.inventories.upsert({"_id": user.id, "bankbalance": bankbal})
         try:
-            await user.send("**{:,}** blew up $`{}` of your money in your bank!".format(ctx.author, int(originalbalance * 0.1)))
+            await user.send("**{}** blew up $`{:,}` of your money in your bank!".format(ctx.author, int(originalbalance * 0.1)))
         except discord.Forbidden:
             pass
 


### PR DESCRIPTION
## Description
Fixing an error which occurs whenever someone attempts to bomb someone. The command still worked although the victim would not be direct messaged and an error would be thrown resulting in a error sent in the command channel.

## Noteable changes
> Fixed bomb error

## Checklist
- [x] Read through yourself
- [x] Runs without any errors
- [x] Clean and easy-to-read code

**FYI** - I am aware this is merging to master, this is intentional