### PR TITLE
Similar to empty ,inv. Shows "your profile" if no user specified

### DIFF
--- a/cogs/profiles.py
+++ b/cogs/profiles.py
@@ -174,7 +174,10 @@ class Profiles(commands.Cog):
 
         description = []
         # Profile title
-        title = f"{user.name}'s Profile"
+        if user == ctx.author:
+            title = f"Your profile"
+        else:
+            title = f"{user.name}'s Profile"
         # Custom title
         color = discord.Color.green()
         try:


### PR DESCRIPTION
## Description
Minor change to ,profile

## Notable changes
> Same as the empty inventory thing. Shows "your profile" when no user specified 

## Checklist
- [x] Read through yourself
- [x] Runs without any errors
- [x] Clean and easy-to-read code
